### PR TITLE
Fix route conflicts by restricting ID patterns

### DIFF
--- a/backend/routes/receipts.js
+++ b/backend/routes/receipts.js
@@ -710,7 +710,8 @@ router.get('/', (req, res) => {
 });
 
 // Get single receipt
-router.get('/:id', (req, res) => {
+// Limit id to digits so /unmatched/list does not get captured
+router.get('/:id(\\d+)', (req, res) => {
   const query = `
     SELECT r.*, 
            GROUP_CONCAT(t.description) as matched_transactions,
@@ -823,7 +824,7 @@ router.post('/upload', upload.single('receipt'), async (req, res) => {
 });
 
 // Update receipt
-router.put('/:id', (req, res) => {
+router.put('/:id(\\d+)', (req, res) => {
   const { extracted_amount, extracted_date, extracted_merchant } = req.body;
   
   const query = `
@@ -844,7 +845,7 @@ router.put('/:id', (req, res) => {
 });
 
 // Delete receipt
-router.delete('/:id', (req, res) => {
+router.delete('/:id(\\d+)', (req, res) => {
   // First get the receipt to delete the file
   db.get('SELECT file_path FROM receipts WHERE id = ?', [req.params.id], (err, row) => {
     if (err) {

--- a/backend/routes/transactions.js
+++ b/backend/routes/transactions.js
@@ -75,7 +75,8 @@ router.get('/', (req, res) => {
 });
 
 // Get single transaction
-router.get('/:id', (req, res) => {
+// Use a numeric id parameter so that other routes like /import are not intercepted
+router.get('/:id(\\d+)', (req, res) => {
   const query = `
     SELECT t.*, 
            GROUP_CONCAT(r.original_filename) as receipts,
@@ -282,7 +283,8 @@ router.post('/import', csvUpload.single('csvFile'), (req, res) => {
 });
 
 // Update transaction
-router.put('/:id', (req, res) => {
+// numeric id ensures proper routing
+router.put('/:id(\\d+)', (req, res) => {
   const { description, amount, category } = req.body;
   
   const query = `
@@ -303,7 +305,7 @@ router.put('/:id', (req, res) => {
 });
 
 // Delete transaction
-router.delete('/:id', (req, res) => {
+router.delete('/:id(\\d+)', (req, res) => {
   db.run('DELETE FROM transactions WHERE id = ?', [req.params.id], function(err) {
     if (err) {
       return res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- restrict `/transactions/:id` and `/receipts/:id` routes to numeric IDs
- prevents `/transactions/import` and `/receipts/unmatched/list` from being captured by the generic routes

## Testing
- `npm test --prefix frontend --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882a3876020832bb837b70124be88b1