### PR TITLE
fix: correct unmatched receipts route order

### DIFF
--- a/backend/routes/receipts.js
+++ b/backend/routes/receipts.js
@@ -709,6 +709,24 @@ router.get('/', (req, res) => {
   });
 });
 
+// Get unmatched receipts
+router.get('/unmatched/list', (req, res) => {
+  const query = `
+    SELECT * FROM receipts r
+    WHERE r.id NOT IN (
+      SELECT receipt_id FROM matches WHERE user_confirmed = 1
+    )
+    AND r.processing_status = 'completed'
+    ORDER BY r.upload_date DESC
+  `;
+
+  db.all(query, [], (err, rows) => {
+    if (err) {
+      return res.status(500).json({ error: err.message });
+    }
+    res.json(rows);
+  });
+});
 // Get single receipt
 router.get('/:id', (req, res) => {
   const query = `
@@ -869,23 +887,5 @@ router.delete('/:id', (req, res) => {
   });
 });
 
-// Get unmatched receipts
-router.get('/unmatched/list', (req, res) => {
-  const query = `
-    SELECT * FROM receipts r
-    WHERE r.id NOT IN (
-      SELECT receipt_id FROM matches WHERE user_confirmed = 1
-    )
-    AND r.processing_status = 'completed'
-    ORDER BY r.upload_date DESC
-  `;
-
-  db.all(query, [], (err, rows) => {
-    if (err) {
-      return res.status(500).json({ error: err.message });
-    }
-    res.json(rows);
-  });
-});
 
 module.exports = router; 


### PR DESCRIPTION
## Summary
- move the `/unmatched/list` route ahead of parameterized routes in `receipts.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a7196948832bb6f22d3ed94cff3b