### PR TITLE
Change backend API port to 6533

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm run dev
 ```
 
 This starts both:
-- Backend server: http://localhost:5000
+- Backend server: http://localhost:6533
 - Frontend app: http://localhost:3000
 
 ## Usage

--- a/backend/server.js
+++ b/backend/server.js
@@ -12,7 +12,7 @@ const receiptRoutes = require('./routes/receipts');
 const matchRoutes = require('./routes/matches');
 
 const app = express();
-const PORT = process.env.PORT || 5000;
+const PORT = process.env.PORT || 6533;
 
 // Middleware
 app.use(cors());

--- a/frontend/src/pages/Receipts.js
+++ b/frontend/src/pages/Receipts.js
@@ -226,7 +226,7 @@ const Receipts = () => {
                         <div className="flex gap-1">
                           {receipt.file_path && (
                             <a
-                              href={`http://localhost:5000/uploads/receipts/${receipt.filename}`}
+                              href={`http://localhost:6533/uploads/receipts/${receipt.filename}`}
                               target="_blank"
                               rel="noopener noreferrer"
                               className="btn btn-sm btn-secondary"

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:6533/api';
 
 const api = axios.create({
   baseURL: API_BASE_URL,

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -4,7 +4,7 @@ module.exports = function(app) {
   app.use(
     '/api',
     createProxyMiddleware({
-      target: 'http://localhost:5000',
+      target: 'http://localhost:6533',
       changeOrigin: true,
     })
   );


### PR DESCRIPTION
## Summary
- update backend to default to port 6533
- update frontend proxy and API base URL
- update receipts link to use new port
- document new backend port

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6882b01db034832b93442fcfe9e43570